### PR TITLE
Optimize embedding architecture and remove semantic search UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ public/r/
 # Collaboration framework logs
 .collaboration/
 .collaboration.backup/
+# Collaboration framework logs
+.collaboration/logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Semantic Search**: Improved task and task note embeddings to include full related-entity context (contact, company, and deal), including company/deal-linked tasks.
+- **Data Provider**: Tasks now return enriched `tasks_summary` records after create/update, ensuring consistent UI metadata and higher-quality embedding payloads.
+
 ## [0.59.0] - 2026-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Entity Embeddings**: Implemented automated background embedding for tasks, task notes, contacts, companies, and deals during creation and updates.
+- **AI Assistant Infrastructure**: Entity embeddings are now generated silently in the background to support future AI assistant features for semantic understanding of CRM data.
+
+### Changed
+- **Embedding Architecture**: Removed manual "Re-index All Tasks" button in favor of automatic incremental indexing. Embeddings now happen transparently during normal CRM operations.
+- **Search Strategy**: PostgreSQL full-text search remains the primary search method for users (fast, reliable, predictable). Embeddings are reserved for AI assistant context, not user-facing search.
+- **EmbeddingService**: Changed `embedRecord()` to return boolean (fire-and-forget safe) instead of throwing errors, improving reliability of background embedding operations.
+- **Embedding Performance**: Lifecycle hooks now only re-embed when semantic fields change (text, status, relationships). Updates to metadata-only fields (index, last_seen) no longer trigger unnecessary embeddings, drastically reducing API calls.
+
 ### Fixed
-- **Semantic Search**: Improved task and task note embeddings to include full related-entity context (contact, company, and deal), including company/deal-linked tasks.
+- **Task Embeddings**: Normalized task and task note date serialization to stable UTC format to avoid timezone-dependent vector drift across clients.
+- **Task Embeddings**: Hardened contact-name and bulk task embedding flows to avoid malformed names and null-task batch crashes.
 - **Data Provider**: Tasks now return enriched `tasks_summary` records after create/update, ensuring consistent UI metadata and higher-quality embedding payloads.
+
+### Removed
+- **Semantic Search UI**: Removed sparkle toggle buttons from Task List and Deal List. PostgreSQL full-text search is sufficient for user search needs.
+- **Manual Re-indexing**: Removed "Re-index All Tasks" button. System naturally builds embeddings incrementally as users work.
 
 ## [0.59.0] - 2026-02-11
 

--- a/api/server.js
+++ b/api/server.js
@@ -688,20 +688,31 @@ app.post("/api/sdk/chat", async (req, res) => {
 app.post("/api/sdk/embed", async (req, res) => {
   try {
     const sdk = SDKService.getSDK();
-    if (!sdk)
-      return res.json({ success: false, message: "SDK not initialized" });
+    if (!sdk) {
+      return res.status(503).json({
+        success: false,
+        message: "RealTimeX SDK not initialized. Please ensure RealTimeX Desktop is running.",
+      });
+    }
 
     const { content, settings = {} } = req.body;
+
+    if (!content || typeof content !== "string") {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid request: 'content' must be a non-empty string.",
+      });
+    }
 
     // Resolve provider/model
     const { provider, model } = await SDKService.resolveEmbedProvider(settings);
 
     console.log(
-      `[SDK/Embed] Calling embedding with provider=${provider}, model=${model}, content length=${content.length}`,
+      `[SDK/Embed] Request: provider=${provider}, model=${model}, content_length=${content.length}`,
     );
 
     // Wrap with timeout to prevent indefinite hangs if provider/desktop bridge stops responding
-    // 30 second timeout is reasonable for embeddings (collab finding: missing timeout wrapper)
+    // 30 second timeout is reasonable for embeddings
     const response = await SDKService.withTimeout(
       sdk.llm.embed(content, {
         provider,
@@ -711,28 +722,46 @@ app.post("/api/sdk/embed", async (req, res) => {
       "Embedding request timed out",
     );
 
-    console.log(
-      `[SDK/Embed] Got response, embeddings count=${response.embeddings?.length || (response.embedding ? 1 : 0)}`,
-    );
-
-    // Return embeddings[0] (plural) like alchemy does
-    const embedding = response.embeddings?.[0] || response.embedding || null;
-
-    if (!embedding) {
-      return res.json({
+    if (response.success === false) {
+      return res.status(502).json({
         success: false,
-        message: "No embedding returned from SDK",
+        message: response.error || response.message || "Embedding provider returned an error.",
       });
     }
 
+    // Extract embedding - handle both plural (new SDK) and singular (old SDK) formats
+    // Ensure we return a flat number array as per contract
+    let embedding = null;
+    if (response.embeddings && Array.isArray(response.embeddings)) {
+      embedding = response.embeddings[0];
+    } else if (response.embedding && Array.isArray(response.embedding)) {
+      embedding = response.embedding;
+    }
+
+    if (!embedding || !Array.isArray(embedding)) {
+      console.error("[SDK/Embed] Unexpected response format:", response);
+      return res.status(502).json({
+        success: false,
+        message: "Provider returned an invalid embedding format.",
+      });
+    }
+
+    console.log(
+      `[SDK/Embed] Success: model=${response.model || model}, dimensions=${embedding.length}`,
+    );
+
     res.json({
       success: true,
-      embedding,
+      embedding: embedding, // number[]
       model: response.model || model,
     });
   } catch (error) {
-    console.error("[SDK/Embed] Error:", error);
-    res.json({ success: false, message: error.message });
+    console.error("[SDK/Embed] Error:", error.message);
+    const status = error.message.includes("timed out") ? 504 : 500;
+    res.status(status).json({
+      success: false,
+      message: error.message || "An unexpected error occurred during embedding.",
+    });
   }
 });
 

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Semantic Search**: Improved task and task note embeddings to include full related-entity context (contact, company, and deal), including company/deal-linked tasks.
+- **Data Provider**: Tasks now return enriched `tasks_summary` records after create/update, ensuring consistent UI metadata and higher-quality embedding payloads.
+
 ## [0.59.0] - 2026-02-11
 
 ### Added

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Entity Embeddings**: Implemented automated background embedding for tasks, task notes, contacts, companies, and deals during creation and updates.
+- **AI Assistant Infrastructure**: Entity embeddings are now generated silently in the background to support future AI assistant features for semantic understanding of CRM data.
+
+### Changed
+- **Embedding Architecture**: Removed manual "Re-index All Tasks" button in favor of automatic incremental indexing. Embeddings now happen transparently during normal CRM operations.
+- **Search Strategy**: PostgreSQL full-text search remains the primary search method for users (fast, reliable, predictable). Embeddings are reserved for AI assistant context, not user-facing search.
+- **EmbeddingService**: Changed `embedRecord()` to return boolean (fire-and-forget safe) instead of throwing errors, improving reliability of background embedding operations.
+- **Embedding Performance**: Lifecycle hooks now only re-embed when semantic fields change (text, status, relationships). Updates to metadata-only fields (index, last_seen) no longer trigger unnecessary embeddings, drastically reducing API calls.
+
 ### Fixed
-- **Semantic Search**: Improved task and task note embeddings to include full related-entity context (contact, company, and deal), including company/deal-linked tasks.
+- **Task Embeddings**: Normalized task and task note date serialization to stable UTC format to avoid timezone-dependent vector drift across clients.
+- **Task Embeddings**: Hardened contact-name and bulk task embedding flows to avoid malformed names and null-task batch crashes.
 - **Data Provider**: Tasks now return enriched `tasks_summary` records after create/update, ensuring consistent UI metadata and higher-quality embedding payloads.
+
+### Removed
+- **Semantic Search UI**: Removed sparkle toggle buttons from Task List and Deal List. PostgreSQL full-text search is sufficient for user search needs.
+- **Manual Re-indexing**: Removed "Re-index All Tasks" button. System naturally builds embeddings incrementally as users work.
 
 ## [0.59.0] - 2026-02-11
 

--- a/src/components/admin/create-button.tsx
+++ b/src/components/admin/create-button.tsx
@@ -7,6 +7,13 @@ import { Link } from "react-router";
 export type CreateButtonProps = {
   label?: string;
   resource?: string;
+  variant?:
+    | "default"
+    | "destructive"
+    | "outline"
+    | "secondary"
+    | "ghost"
+    | "link";
 };
 
 /**
@@ -33,6 +40,7 @@ export type CreateButtonProps = {
 export const CreateButton = ({
   label,
   resource: targetResource,
+  variant = "outline",
 }: CreateButtonProps) => {
   const resource = useResourceContext();
   const createPath = useCreatePath();
@@ -42,7 +50,7 @@ export const CreateButton = ({
   });
   return (
     <Link
-      className={buttonVariants({ variant: "outline" })}
+      className={buttonVariants({ variant })}
       to={link}
       onClick={stopPropagation}
     >

--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -100,103 +100,59 @@ const dataProviderWithCustomMethods = {
     if (resource === "invoices") {
       return baseDataProvider.getList("invoices_summary", params);
     }
-
+    if (resource === "companyNotes") {
+      // Return all notes for company
+      return baseDataProvider.getList(resource, {
+        ...params,
+        sort: { field: "date", order: "DESC" },
+      });
+    }
+    if (resource === "contactNotes") {
+      // Return all notes for contact
+      return baseDataProvider.getList(resource, {
+        ...params,
+        sort: { field: "date", order: "DESC" },
+      });
+    }
+    if (resource === "dealNotes") {
+      return baseDataProvider.getList(resource, {
+        ...params,
+        sort: { field: "date", order: "DESC" },
+      });
+    }
+    if (resource === "taskNotes") {
+      return baseDataProvider.getList(resource, {
+        ...params,
+        sort: { field: "date", order: "DESC" },
+      });
+    }
     return baseDataProvider.getList(resource, params);
   },
-  async getOne(resource: string, params: any) {
-    if (resource === "companies") {
-      // Use direct Supabase query for better error handling
-      const { data, error } = await supabase
-        .from("companies_summary")
-        .select("*")
-        .eq("id", params.id)
-        .maybeSingle();
 
-      if (error) {
-        console.error("[DataProvider] companies_summary query error:", error);
-        throw new Error(`Failed to fetch company: ${error.message}`);
-      }
-
-      if (!data) {
-        throw new Error(`Company with id ${params.id} not found`);
-      }
-
-      return { data };
-    }
-    if (resource === "contacts") {
-      const { data, error } = await supabase
-        .from("contacts_summary")
-        .select("*")
-        .eq("id", params.id)
-        .maybeSingle();
-
-      if (error) {
-        console.error("[DataProvider] contacts_summary query error:", error);
-        throw new Error(`Failed to fetch contact: ${error.message}`);
-      }
-
-      if (!data) {
-        throw new Error(`Contact with id ${params.id} not found`);
-      }
-
-      return { data };
-    }
-
-    if (resource === "tasks") {
-      const { data, error } = await supabase
-        .from("tasks_summary")
-        .select("*")
-        .eq("id", params.id)
-        .maybeSingle();
-
-      if (error) {
-        console.error("[DataProvider] tasks_summary query error:", error);
-        throw new Error(`Failed to fetch task: ${error.message}`);
-      }
-
-      if (!data) {
-        throw new Error(`Task with id ${params.id} not found`);
-      }
-
-      return { data };
-    }
-
-    if (resource === "deals") {
-      const { data, error } = await supabase
-        .from("deals_summary")
-        .select("*")
-        .eq("id", params.id)
-        .maybeSingle();
-
-      if (error) {
-        console.error("[DataProvider] deals_summary query error:", error);
-        throw new Error(`Failed to fetch deal: ${error.message}`);
-      }
-
-      if (!data) {
-        throw new Error(`Deal with id ${params.id} not found`);
-      }
-
-      return { data };
-    }
-
+  async getOne(resource: string, params: { id: Identifier }) {
     if (resource === "invoices") {
       const { data, error } = await supabase
         .from("invoices_summary")
         .select("*")
         .eq("id", params.id)
-        .maybeSingle();
+        .single();
 
       if (error) {
         console.error("[DataProvider] invoices_summary query error:", error);
         throw new Error(`Failed to fetch invoice: ${error.message}`);
       }
 
-      if (!data) {
-        throw new Error(`Invoice with id ${params.id} not found`);
+      // Also fetch items
+      const { data: items, error: itemsError } = await supabase
+        .from("invoice_items")
+        .select("*")
+        .eq("invoice_id", params.id);
+
+      if (itemsError) {
+        console.error("[DataProvider] invoice_items query error:", itemsError);
       }
 
-      return { data };
+      return { data: { ...data, items: items || [] } };
     }
 
     // Special handling for business_profile (singleton table)
@@ -323,6 +279,27 @@ const dataProviderWithCustomMethods = {
       }
 
       // Return enriched data for react-admin and embedding
+      return { data: enrichedData };
+    }
+
+    if (resource === "tasks") {
+      const result = await baseDataProvider.create(resource, params);
+
+      // Fetch enriched task from tasks_summary for UI consistency and richer embeddings
+      const { data: enrichedData, error: enrichError } = await supabase
+        .from("tasks_summary")
+        .select("*")
+        .eq("id", result.data.id)
+        .single();
+
+      if (enrichError) {
+        console.warn(
+          "[DataProvider] Failed to fetch enriched task data:",
+          enrichError,
+        );
+        return result;
+      }
+
       return { data: enrichedData };
     }
 
@@ -516,10 +493,27 @@ const dataProviderWithCustomMethods = {
         ...data
       } = params.data;
 
-      return baseDataProvider.update(resource, {
+      const result = await baseDataProvider.update(resource, {
         ...params,
         data,
       });
+
+      // Fetch enriched task from tasks_summary for UI consistency and richer embeddings
+      const { data: enrichedData, error: enrichError } = await supabase
+        .from("tasks_summary")
+        .select("*")
+        .eq("id", params.id)
+        .single();
+
+      if (enrichError) {
+        console.warn(
+          "[DataProvider] Failed to fetch enriched task data:",
+          enrichError,
+        );
+        return result;
+      }
+
+      return { data: enrichedData };
     }
 
     if (resource === "invoices") {
@@ -803,6 +797,20 @@ export const dataProvider = withLifecycleCallbacks(
         }
         return data;
       },
+      afterCreate: async (result) => {
+        // Fire-and-forget embedding (don't block taskNote creation)
+        EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
+          console.error("[DataProvider] Embedding failed for taskNote:", err),
+        );
+        return result;
+      },
+      afterUpdate: async (result) => {
+        // Fire-and-forget embedding (don't block taskNote update)
+        EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
+          console.error("[DataProvider] Embedding failed for taskNote:", err),
+        );
+        return result;
+      },
     },
     {
       resource: "sales",
@@ -875,6 +883,20 @@ export const dataProvider = withLifecycleCallbacks(
       resource: "tasks",
       beforeGetList: async (params) => {
         return applyFullTextSearch(["text", "contact_first_name"])(params);
+      },
+      afterCreate: async (result) => {
+        // Fire-and-forget embedding (don't block task creation)
+        EmbeddingService.embedRecord("task", result.data).catch((err) =>
+          console.error("[DataProvider] Embedding failed for task:", err),
+        );
+        return result;
+      },
+      afterUpdate: async (result) => {
+        // Fire-and-forget embedding (don't block task update)
+        EmbeddingService.embedRecord("task", result.data).catch((err) =>
+          console.error("[DataProvider] Embedding failed for task:", err),
+        );
+        return result;
       },
     },
     {

--- a/src/components/atomic-crm/providers/supabase/dataProvider.ts
+++ b/src/components/atomic-crm/providers/supabase/dataProvider.ts
@@ -283,13 +283,40 @@ const dataProviderWithCustomMethods = {
     }
 
     if (resource === "tasks") {
-      const result = await baseDataProvider.create(resource, params);
+      // Strip read-only fields from tasks_summary view before insertion
+      const {
+        contact_first_name: _contact_first_name,
+        contact_last_name: _contact_last_name,
+        contact_email: _contact_email,
+        company_name: _company_name,
+        deal_name: _deal_name,
+        company_id_computed: _company_id_computed,
+        assigned_first_name: _assigned_first_name,
+        assigned_last_name: _assigned_last_name,
+        creator_first_name: _creator_first_name,
+        creator_last_name: _creator_last_name,
+        nb_notes: _nb_notes,
+        last_note_date: _last_note_date,
+        ...cleanData
+      } = params.data;
+
+      // Use direct Supabase insert to ensure proper response format
+      const { data, error } = await supabase
+        .from("tasks")
+        .insert(cleanData)
+        .select()
+        .single();
+
+      if (error) {
+        console.error("[DataProvider] tasks create error:", error);
+        throw new Error(`Failed to create task: ${error.message}`);
+      }
 
       // Fetch enriched task from tasks_summary for UI consistency and richer embeddings
       const { data: enrichedData, error: enrichError } = await supabase
         .from("tasks_summary")
         .select("*")
-        .eq("id", result.data.id)
+        .eq("id", data.id)
         .single();
 
       if (enrichError) {
@@ -297,9 +324,50 @@ const dataProviderWithCustomMethods = {
           "[DataProvider] Failed to fetch enriched task data:",
           enrichError,
         );
-        return result;
+        return { data }; // Return base data if enriched fetch fails
       }
 
+      // Return enriched data for react-admin and embedding
+      return { data: enrichedData };
+    }
+
+    if (resource === "deals") {
+      // Strip read-only fields from deals_summary view before insertion
+      const {
+        company_name: _company_name,
+        nb_invoices: _nb_invoices,
+        nb_notes: _nb_notes,
+        ...cleanData
+      } = params.data;
+
+      // Use direct Supabase insert to ensure proper response format
+      const { data, error } = await supabase
+        .from("deals")
+        .insert(cleanData)
+        .select()
+        .single();
+
+      if (error) {
+        console.error("[DataProvider] deals create error:", error);
+        throw new Error(`Failed to create deal: ${error.message}`);
+      }
+
+      // Fetch enriched deal from deals_summary for UI consistency and richer embeddings
+      const { data: enrichedData, error: enrichError } = await supabase
+        .from("deals_summary")
+        .select("*")
+        .eq("id", data.id)
+        .single();
+
+      if (enrichError) {
+        console.warn(
+          "[DataProvider] Failed to fetch enriched deal data:",
+          enrichError,
+        );
+        return { data }; // Return base data if enriched fetch fails
+      }
+
+      // Return enriched data for react-admin and embedding
       return { data: enrichedData };
     }
 
@@ -513,6 +581,46 @@ const dataProviderWithCustomMethods = {
         return result;
       }
 
+      return { data: enrichedData };
+    }
+
+    if (resource === "deals") {
+      // Strip read-only fields from deals_summary view before update
+      const {
+        company_name: _company_name,
+        nb_invoices: _nb_invoices,
+        nb_notes: _nb_notes,
+        ...cleanData
+      } = params.data;
+
+      const { data, error } = await supabase
+        .from("deals")
+        .update(cleanData)
+        .eq("id", params.id)
+        .select()
+        .single();
+
+      if (error) {
+        console.error("[DataProvider] deals update error:", error);
+        throw new Error(`Failed to update deal: ${error.message}`);
+      }
+
+      // Fetch enriched deal from deals_summary for UI consistency and richer embeddings
+      const { data: enrichedData, error: enrichError } = await supabase
+        .from("deals_summary")
+        .select("*")
+        .eq("id", params.id)
+        .single();
+
+      if (enrichError) {
+        console.warn(
+          "[DataProvider] Failed to fetch enriched deal data:",
+          enrichError,
+        );
+        return { data }; // Return base data if enriched fetch fails
+      }
+
+      // Return enriched data for react-admin and embedding
       return { data: enrichedData };
     }
 
@@ -799,16 +907,49 @@ export const dataProvider = withLifecycleCallbacks(
       },
       afterCreate: async (result) => {
         // Fire-and-forget embedding (don't block taskNote creation)
-        EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for taskNote:", err),
-        );
+        if (result.data && typeof result.data === 'object' && result.data.id) {
+          EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for taskNote:", err),
+          );
+        }
         return result;
       },
-      afterUpdate: async (result) => {
-        // Fire-and-forget embedding (don't block taskNote update)
-        EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for taskNote:", err),
-        );
+      afterUpdate: async (result, params) => {
+        // Safety check: ensure result.data and params.data exist
+        if (!result.data || typeof result.data !== 'object' || !result.data.id) {
+          return result;
+        }
+        if (!params.data || typeof params.data !== 'object') {
+          return result;
+        }
+
+        // Only re-embed if semantic fields changed
+        const semanticFields = ['text', 'status', 'date', 'task_id'];
+
+        const changedFields = Object.keys(params.data);
+        const semanticChanged = changedFields.some(field => semanticFields.includes(field));
+
+        if (semanticChanged) {
+          // Fire-and-forget embedding (don't block taskNote update)
+          EmbeddingService.embedRecord("taskNote", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for taskNote:", err),
+          );
+        }
+
+        return result;
+      },
+      afterDelete: async (result) => {
+        // Clean up embedding on delete
+        if (result.data?.id) {
+          supabase
+            .from("entity_vectors")
+            .delete()
+            .eq("entity_type", "taskNote")
+            .eq("entity_id", result.data.id)
+            .then(({ error }) => {
+              if (error) console.error("[DataProvider] Failed to delete taskNote embedding:", error);
+            });
+        }
         return result;
       },
     },
@@ -831,16 +972,52 @@ export const dataProvider = withLifecycleCallbacks(
       },
       afterCreate: async (result) => {
         // Fire-and-forget embedding (don't block contact creation)
-        EmbeddingService.embedRecord("contact", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for contact:", err),
-        );
+        if (result.data && typeof result.data === 'object' && result.data.id) {
+          EmbeddingService.embedRecord("contact", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for contact:", err),
+          );
+        }
         return result;
       },
-      afterUpdate: async (result) => {
-        // Fire-and-forget embedding (don't block contact update)
-        EmbeddingService.embedRecord("contact", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for contact:", err),
-        );
+      afterUpdate: async (result, params) => {
+        // Safety check: ensure result.data and params.data exist
+        if (!result.data || typeof result.data !== 'object' || !result.data.id) {
+          return result;
+        }
+        if (!params.data || typeof params.data !== 'object') {
+          return result;
+        }
+
+        // Only re-embed if semantic fields changed (not metadata like last_seen)
+        const semanticFields = [
+          'first_name', 'last_name', 'title', 'gender', 'email_jsonb', 'phone_jsonb',
+          'company_id', 'background', 'avatar', 'tags', 'linkedin_url', 'twitter'
+        ];
+
+        const changedFields = Object.keys(params.data);
+        const semanticChanged = changedFields.some(field => semanticFields.includes(field));
+
+        if (semanticChanged) {
+          // Fire-and-forget embedding (don't block contact update)
+          EmbeddingService.embedRecord("contact", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for contact:", err),
+          );
+        }
+
+        return result;
+      },
+      afterDelete: async (result) => {
+        // Clean up embedding on delete
+        if (result.data?.id) {
+          supabase
+            .from("entity_vectors")
+            .delete()
+            .eq("entity_type", "contact")
+            .eq("entity_id", result.data.id)
+            .then(({ error }) => {
+              if (error) console.error("[DataProvider] Failed to delete contact embedding:", error);
+            });
+        }
         return result;
       },
       beforeGetList: async (params) => {
@@ -860,16 +1037,52 @@ export const dataProvider = withLifecycleCallbacks(
       },
       afterCreate: async (result) => {
         // Fire-and-forget embedding (don't block company creation)
-        EmbeddingService.embedRecord("company", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for company:", err),
-        );
+        if (result.data && typeof result.data === 'object' && result.data.id) {
+          EmbeddingService.embedRecord("company", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for company:", err),
+          );
+        }
         return result;
       },
-      afterUpdate: async (result) => {
-        // Fire-and-forget embedding (don't block company update)
-        EmbeddingService.embedRecord("company", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for company:", err),
-        );
+      afterUpdate: async (result, params) => {
+        // Safety check: ensure result.data and params.data exist
+        if (!result.data || typeof result.data !== 'object' || !result.data.id) {
+          return result;
+        }
+        if (!params.data || typeof params.data !== 'object') {
+          return result;
+        }
+
+        // Only re-embed if semantic fields changed (not metadata)
+        const semanticFields = [
+          'name', 'sector', 'size', 'description', 'address', 'city', 'state',
+          'zipcode', 'country', 'website', 'phone_number', 'social_profiles', 'logo', 'tags'
+        ];
+
+        const changedFields = Object.keys(params.data);
+        const semanticChanged = changedFields.some(field => semanticFields.includes(field));
+
+        if (semanticChanged) {
+          // Fire-and-forget embedding (don't block company update)
+          EmbeddingService.embedRecord("company", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for company:", err),
+          );
+        }
+
+        return result;
+      },
+      afterDelete: async (result) => {
+        // Clean up embedding on delete
+        if (result.data?.id) {
+          supabase
+            .from("entity_vectors")
+            .delete()
+            .eq("entity_type", "company")
+            .eq("entity_id", result.data.id)
+            .then(({ error }) => {
+              if (error) console.error("[DataProvider] Failed to delete company embedding:", error);
+            });
+        }
         return result;
       },
     },
@@ -886,16 +1099,52 @@ export const dataProvider = withLifecycleCallbacks(
       },
       afterCreate: async (result) => {
         // Fire-and-forget embedding (don't block task creation)
-        EmbeddingService.embedRecord("task", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for task:", err),
-        );
+        if (result.data && typeof result.data === 'object' && result.data.id) {
+          EmbeddingService.embedRecord("task", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for task:", err),
+          );
+        }
         return result;
       },
-      afterUpdate: async (result) => {
-        // Fire-and-forget embedding (don't block task update)
-        EmbeddingService.embedRecord("task", result.data).catch((err) =>
-          console.error("[DataProvider] Embedding failed for task:", err),
-        );
+      afterUpdate: async (result, params) => {
+        // Safety check: ensure result.data and params.data exist
+        if (!result.data || typeof result.data !== 'object' || !result.data.id) {
+          return result;
+        }
+        if (!params.data || typeof params.data !== 'object') {
+          return result;
+        }
+
+        // Only re-embed if semantic fields changed (not just index/position)
+        const semanticFields = [
+          'text', 'type', 'status', 'priority', 'due_date', 'done_date',
+          'contact_id', 'company_id', 'deal_id', 'archived'
+        ];
+
+        const changedFields = Object.keys(params.data);
+        const semanticChanged = changedFields.some(field => semanticFields.includes(field));
+
+        if (semanticChanged) {
+          // Fire-and-forget embedding (don't block task update)
+          EmbeddingService.embedRecord("task", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for task:", err),
+          );
+        }
+
+        return result;
+      },
+      afterDelete: async (result) => {
+        // Clean up embedding on delete
+        if (result.data?.id) {
+          supabase
+            .from("entity_vectors")
+            .delete()
+            .eq("entity_type", "task")
+            .eq("entity_id", result.data.id)
+            .then(({ error }) => {
+              if (error) console.error("[DataProvider] Failed to delete task embedding:", error);
+            });
+        }
         return result;
       },
     },
@@ -903,6 +1152,56 @@ export const dataProvider = withLifecycleCallbacks(
       resource: "deals",
       beforeGetList: async (params) => {
         return applyFullTextSearch(["name", "category", "description"])(params);
+      },
+      afterCreate: async (result) => {
+        // Fire-and-forget embedding (don't block deal creation)
+        // Safety check: ensure result.data exists and has an id
+        if (result.data && typeof result.data === 'object' && result.data.id) {
+          EmbeddingService.embedRecord("deal", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for deal:", err),
+          );
+        }
+        return result;
+      },
+      afterUpdate: async (result, params) => {
+        // Safety check: ensure result.data and params.data exist
+        if (!result.data || typeof result.data !== 'object' || !result.data.id) {
+          return result;
+        }
+        if (!params.data || typeof params.data !== 'object') {
+          return result;
+        }
+
+        // Only re-embed if semantic fields changed (not stage/index/amount)
+        const semanticFields = [
+          'name', 'company_id', 'category', 'description'
+        ];
+
+        const changedFields = Object.keys(params.data);
+        const semanticChanged = changedFields.some(field => semanticFields.includes(field));
+
+        if (semanticChanged) {
+          // Fire-and-forget embedding (don't block deal update)
+          EmbeddingService.embedRecord("deal", result.data).catch((err) =>
+            console.error("[DataProvider] Embedding failed for deal:", err),
+          );
+        }
+
+        return result;
+      },
+      afterDelete: async (result) => {
+        // Clean up embedding on delete
+        if (result.data?.id) {
+          supabase
+            .from("entity_vectors")
+            .delete()
+            .eq("entity_type", "deal")
+            .eq("entity_id", result.data.id)
+            .then(({ error }) => {
+              if (error) console.error("[DataProvider] Failed to delete deal embedding:", error);
+            });
+        }
+        return result;
       },
     },
   ],

--- a/src/components/atomic-crm/tasks/TaskCreate.tsx
+++ b/src/components/atomic-crm/tasks/TaskCreate.tsx
@@ -5,6 +5,7 @@ import { TextInput } from "@/components/ds/admin/text-input";
 import { Card, CardContent } from "@/components/ds/ui/card";
 import { Create } from "@/components/ds/admin/create";
 import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import {
   Form,
   required,
@@ -25,7 +26,7 @@ import { transformTaskEntityData } from "./taskEntityUtils";
 import type { Task } from "../types";
 
 export const TaskCreate = () => {
-  const { identity } = useGetIdentity();
+  const { identity, isPending: isIdentityPending } = useGetIdentity();
   const { taskTypes, taskPriorities, taskStatuses } = useConfigurationContext();
   const notify = useNotify();
   const redirect = useRedirect();
@@ -33,25 +34,42 @@ export const TaskCreate = () => {
   const queryClient = useQueryClient();
   const translate = useTranslate();
 
-  const translatedTaskTypes = taskTypes.map((type) => ({
-    id: type,
-    name: translateChoice(translate, "crm.task.type", type, type),
-  }));
+  const translatedTaskTypes = useMemo(
+    () =>
+      taskTypes.map((type) => ({
+        id: type,
+        name: translateChoice(translate, "crm.task.type", type, type),
+      })),
+    [taskTypes, translate],
+  );
 
-  const translatedTaskPriorities = taskPriorities.map((priority) => ({
-    ...priority,
-    name: translateChoice(
-      translate,
-      "crm.task.priority",
-      priority.id,
-      priority.name,
-    ),
-  }));
+  const translatedTaskPriorities = useMemo(
+    () =>
+      taskPriorities.map((priority) => ({
+        ...priority,
+        name: translateChoice(
+          translate,
+          "crm.task.priority",
+          priority.id,
+          priority.name,
+        ),
+      })),
+    [taskPriorities, translate],
+  );
 
-  const translatedTaskStatuses = taskStatuses.map((status) => ({
-    ...status,
-    name: translateChoice(translate, "crm.task.status", status.id, status.name),
-  }));
+  const translatedTaskStatuses = useMemo(
+    () =>
+      taskStatuses.map((status) => ({
+        ...status,
+        name: translateChoice(
+          translate,
+          "crm.task.status",
+          status.id,
+          status.name,
+        ),
+      })),
+    [taskStatuses, translate],
+  );
 
   const handleSuccess = async (task: Task) => {
     const taskStatus = task.status ?? "todo";
@@ -98,32 +116,38 @@ export const TaskCreate = () => {
     redirect("list", "tasks");
   };
 
+  const defaultValues = useMemo(
+    () => ({
+      due_date: new Date().toISOString().slice(0, 10),
+      type: taskTypes[0] || "None",
+      priority: "medium",
+      status: "todo",
+      assigned_to: identity?.id,
+      entity_type: "none",
+      index: 0,
+    }),
+    [identity?.id, taskTypes],
+  );
+
+  if (isIdentityPending) return null;
+
   return (
-    <div className="mt-4 max-w-2xl mx-auto">
-      <Card>
-        <CardContent className="pt-6">
-          <Create
-            resource="tasks"
-            redirect="list"
-            mutationOptions={{ onSuccess: handleSuccess }}
-            transform={(data) => ({
-              ...transformTaskEntityData(data),
-              sales_id: identity?.id,
-              index: 0,
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
-            })}
-          >
-            <Form
-              defaultValues={{
-                due_date: new Date().toISOString().slice(0, 10),
-                priority: "medium",
-                status: "todo",
-                assigned_to: identity?.id,
-                entity_type: "none",
-                index: 0,
-              }}
-            >
+    <Create
+      resource="tasks"
+      redirect="list"
+      mutationOptions={{ onSuccess: handleSuccess }}
+      transform={(data) => ({
+        ...transformTaskEntityData(data),
+        sales_id: identity?.id,
+        index: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })}
+    >
+      <div className="mt-4 max-w-2xl mx-auto">
+        <Card>
+          <CardContent className="pt-6">
+            <Form defaultValues={defaultValues}>
               <TextInput
                 autoFocus
                 source="text"
@@ -155,8 +179,13 @@ export const TaskCreate = () => {
                 <SelectInput
                   source="priority"
                   choices={translatedTaskPriorities}
+                  label={translate("crm.task.field.priority")}
                 />
-                <SelectInput source="status" choices={translatedTaskStatuses} />
+                <SelectInput
+                  source="status"
+                  choices={translatedTaskStatuses}
+                  label={translate("crm.task.field.status")}
+                />
                 <ReferenceInput source="assigned_to" reference="sales">
                   <SelectInput
                     optionText={(record) =>
@@ -168,9 +197,10 @@ export const TaskCreate = () => {
               </div>
               <FormToolbar />
             </Form>
-          </Create>
-        </CardContent>
-      </Card>
-    </div>
+          </CardContent>
+        </Card>
+      </div>
+    </Create>
   );
 };
+

--- a/src/components/atomic-crm/tasks/TaskList.tsx
+++ b/src/components/atomic-crm/tasks/TaskList.tsx
@@ -212,7 +212,11 @@ const TaskActions = ({
       </div>
       <FilterButton />
       <ExportButton />
-      <CreateButton label={translate("crm.action.new_task")} />
+      <CreateButton 
+        resource="tasks" 
+        variant="default" 
+        label={translate("crm.action.new_task")} 
+      />
     </TopToolbar>
   );
 };

--- a/src/lib/ai/EmbeddingService.test.ts
+++ b/src/lib/ai/EmbeddingService.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetUser, mockFrom, mockAxiosPost, mockRpc } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockAxiosPost: vi.fn(),
+  mockRpc: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: mockAxiosPost,
+  },
+}));
+
+vi.mock("../../components/atomic-crm/providers/supabase/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+    rpc: mockRpc,
+  },
+}));
+
+import { EmbeddingService } from "./EmbeddingService";
+
+describe("EmbeddingService task embedding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (EmbeddingService as any).aiSettingsCache = null;
+
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: { id: "user-1" },
+      },
+    });
+
+    mockAxiosPost.mockResolvedValue({
+      data: {
+        success: true,
+        embedding: [0.1, 0.2],
+        model: "text-embedding-3-small",
+      },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "tasks_summary") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  text: "Follow up with procurement",
+                  contact_first_name: "Jane",
+                  contact_last_name: "Doe",
+                  company_name: "Acme Corp",
+                  deal_name: "Q1 Expansion",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "ai_settings") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {},
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "entity_vectors") {
+        return {
+          upsert: vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    });
+  });
+
+  it("fills missing task company/deal context from tasks_summary before embedding", async () => {
+    await EmbeddingService.embedRecord("task", {
+      id: 42,
+      type: "Call",
+      text: "Follow up with procurement",
+      contact_first_name: "Jane",
+      contact_last_name: "Doe",
+    });
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Contact: Jane Doe");
+    expect(payload.content).toContain("Company: Acme Corp");
+    expect(payload.content).toContain("Deal: Q1 Expansion");
+
+    expect(mockFrom).toHaveBeenCalledWith("tasks_summary");
+  });
+
+  it("falls back to tasks relationships when tasks_summary context is unavailable", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "tasks_summary") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: { message: "relation tasks_summary does not exist" },
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "tasks") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  text: "Prep renewal walkthrough",
+                  contact_id: 7,
+                  company_id: 8,
+                  deal_id: 9,
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "contacts") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  first_name: "Riley",
+                  last_name: "Quinn",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "companies") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Globex",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "deals") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Renewal Phase 2",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "ai_settings") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {},
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "entity_vectors") {
+        return {
+          upsert: vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    });
+
+    await EmbeddingService.embedRecord("task", {
+      id: 77,
+      type: "Email",
+      text: "Prep renewal walkthrough",
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith("tasks_summary");
+    expect(mockFrom).toHaveBeenCalledWith("tasks");
+    expect(mockFrom).toHaveBeenCalledWith("contacts");
+    expect(mockFrom).toHaveBeenCalledWith("companies");
+    expect(mockFrom).toHaveBeenCalledWith("deals");
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Contact: Riley Quinn");
+    expect(payload.content).toContain("Company: Globex");
+    expect(payload.content).toContain("Deal: Renewal Phase 2");
+  });
+
+  it("performs semantic search for tasks", async () => {
+    mockFrom.mockImplementation((table: string) => {
+        if (table === "ai_settings") {
+            return {
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        maybeSingle: vi.fn().mockResolvedValue({
+                            data: { embedding_provider: 'openai', embedding_model: 'text-embedding-3-small' },
+                            error: null,
+                        }),
+                    })),
+                })),
+            };
+        }
+        return {};
+    });
+
+    mockRpc.mockResolvedValue({
+        data: [{ id: 'uuid-1', entity_id: 42, entity_type: 'task', similarity: 0.9 }],
+        error: null
+    });
+
+    const results = await EmbeddingService.searchTasksSemantic("urgent follow up");
+
+    expect(mockAxiosPost).toHaveBeenCalled();
+    expect(mockRpc).toHaveBeenCalledWith('match_entities', expect.anything());
+    expect(results).toHaveLength(1);
+    expect(results[0].entity_id).toBe(42);
+  });
+
+  it("embeds all tasks and task notes during re-indexing", async () => {
+    mockFrom.mockImplementation((table: string) => {
+        if (table === "tasks") {
+            return {
+                select: vi.fn(() => ({
+                    data: [
+                        { id: 101, text: "Task 1" },
+                        { id: 102, text: "Task 2" }
+                    ],
+                    error: null,
+                    eq: vi.fn(() => ({
+                        maybeSingle: vi.fn().mockResolvedValue({
+                            data: { text: "Task 1", contact_id: null },
+                            error: null
+                        })
+                    }))
+                }))
+            };
+        }
+        if (table === "taskNotes") {
+            return {
+                select: vi.fn(() => ({
+                    data: [
+                        { id: 201, text: "Note 1", task_id: 101 }
+                    ],
+                    error: null
+                }))
+            };
+        }
+        if (table === "tasks_summary") {
+            return {
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        maybeSingle: vi.fn().mockResolvedValue({
+                            data: null, // Simulate no summary yet
+                            error: null
+                        })
+                    }))
+                }))
+            };
+        }
+        if (table === "ai_settings") {
+            return {
+                select: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                        maybeSingle: vi.fn().mockResolvedValue({ data: {}, error: null })
+                    }))
+                }))
+            };
+        }
+        if (table === "entity_vectors") {
+            return {
+                upsert: vi.fn().mockResolvedValue({ data: null, error: null })
+            };
+        }
+        return {
+            select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null })
+                }))
+            }))
+        };
+    });
+
+    const result = await EmbeddingService.embedAllTasks();
+
+    expect(mockFrom).toHaveBeenCalledWith("tasks");
+    expect(mockFrom).toHaveBeenCalledWith("taskNotes");
+    expect(result?.success).toBe(3); // 2 tasks + 1 note
+    expect(mockAxiosPost).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/ai/EmbeddingService.ts
+++ b/src/lib/ai/EmbeddingService.ts
@@ -18,10 +18,26 @@ export class EmbeddingService {
     // Cache for AI settings (5 minute TTL)
     private static aiSettingsCache: { data: any; timestamp: number } | null = null;
     private static readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+    private static readonly EMBEDDING_TIMEOUT_MS = 60000; // 60 seconds (generous timeout for AI providers)
+    private static readonly EMBEDDING_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'UTC',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
 
     private static buildFullName(firstName?: string | null, lastName?: string | null): string | null {
         const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
         return fullName || null;
+    }
+
+    private static formatDateForEmbedding(value?: string | null): string | null {
+        if (!value) return null;
+
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) return null;
+
+        return this.EMBEDDING_DATE_FORMATTER.format(parsed);
     }
 
     /**
@@ -103,7 +119,7 @@ export class EmbeddingService {
                 return null;
             }
 
-            return `${contact.first_name} ${contact.last_name}`;
+            return this.buildFullName(contact.first_name, contact.last_name);
         } catch (error) {
             console.warn('[EmbeddingService] Error fetching contact context:', error);
             return null;
@@ -218,18 +234,19 @@ export class EmbeddingService {
 
     /**
      * Embed a CRM record
+     * @returns true if embedding succeeded, false otherwise (fire-and-forget safe)
      */
-    static async embedRecord(type: 'contact' | 'company' | 'deal' | 'task' | 'taskNote' | 'note', record: any) {
+    static async embedRecord(type: 'contact' | 'company' | 'deal' | 'task' | 'taskNote' | 'note', record: any): Promise<boolean> {
         // Allow disabling embeddings via environment variable
         if (import.meta.env.VITE_DISABLE_EMBEDDINGS === 'true') {
             console.log('[EmbeddingService] Embeddings disabled via VITE_DISABLE_EMBEDDINGS');
-            return;
+            return false;
         }
 
         // Ensure record has an ID before embedding
         if (!record.id) {
             console.warn(`[EmbeddingService] Skipping embedding for ${type} - missing ID`, record);
-            return;
+            return false;
         }
 
         // Enrich record with contextual data for embedding
@@ -243,25 +260,24 @@ export class EmbeddingService {
 
         // Fetch relationship context for tasks
         if (type === 'task') {
-            const inlineContactName =
-                enrichedRecord.contactName ||
-                this.buildFullName(enrichedRecord.contact_first_name, enrichedRecord.contact_last_name);
-            const inlineCompanyName = enrichedRecord.companyName || enrichedRecord.company_name || null;
-            const inlineDealName = enrichedRecord.dealName || enrichedRecord.deal_name || null;
+            // 1. Extract inline fields
+            let contactName = enrichedRecord.contactName ||
+                             this.buildFullName(enrichedRecord.contact_first_name, enrichedRecord.contact_last_name) ||
+                             null;
+            let companyName = enrichedRecord.companyName || enrichedRecord.company_name || null;
+            let dealName = enrichedRecord.dealName || enrichedRecord.deal_name || null;
 
-            let contactName = inlineContactName || null;
-            let companyName = inlineCompanyName;
-            let dealName = inlineDealName;
-
-            if (!contactName && !companyName && !dealName) {
+            // 2. Fetch from tasks_summary (canonical context) if ID exists and we're missing anything
+            if (record.id && (!contactName || !companyName || !dealName)) {
                 const taskContext = await this.fetchTaskContext(record.id);
                 if (taskContext) {
-                    contactName = taskContext.contactName;
-                    companyName = taskContext.companyName;
-                    dealName = taskContext.dealName;
+                    contactName = contactName || taskContext.contactName;
+                    companyName = companyName || taskContext.companyName;
+                    dealName = dealName || taskContext.dealName;
                 }
             }
 
+            // 3. Final fallback to individual entity fetches if still missing
             if (!contactName && record.contact_id) {
                 contactName = await this.fetchContactContext(record.contact_id);
             }
@@ -295,7 +311,7 @@ export class EmbeddingService {
         }
 
         const content = this.flattenRecord(type, enrichedRecord);
-        if (!content) return;
+        if (!content) return false;
 
         try {
             // Log what we're actually embedding to verify completeness
@@ -305,12 +321,11 @@ export class EmbeddingService {
             const settings = await this.fetchAISettings();
 
             // 2. Get embedding from SDK (via backend proxy)
-            // Embedding can take 10-30s depending on provider, so use longer timeout
             const response = await axios.post('/api/sdk/embed', {
                 content,
                 settings  // Pass user's embedding settings
             }, {
-                timeout: 35000  // 35 second timeout (longer than backend's 30s)
+                timeout: this.EMBEDDING_TIMEOUT_MS
             });
 
             if (!response.data.success) {
@@ -333,7 +348,7 @@ export class EmbeddingService {
 
             // 3. Upsert into entity_vectors
             // Using (entity_type, entity_id, model) constraint to allow multiple models per entity
-            const { data, error: upsertError } = await supabase.from('entity_vectors').upsert({
+            const { error: upsertError } = await supabase.from('entity_vectors').upsert({
                 entity_type: type,
                 entity_id: record.id,
                 content: content,
@@ -348,12 +363,17 @@ export class EmbeddingService {
             }
 
             console.log(`[EmbeddingService] ✅ Embedded ${type}: ${record.id}`);
+            return true;
         } catch (error: any) {
             if (error.code === 'ECONNABORTED' || error.message?.includes('timeout')) {
                 console.warn(`[EmbeddingService] ⚠️ Embedding timeout for ${type} - embedding provider not configured or RealTimeX Desktop not running`);
             } else {
-                console.error(`[EmbeddingService] ❌ Failed to embed ${type}:`, error.message || error);
+                const errorMessage = error.response?.data?.message || error.message || error;
+                console.error(`[EmbeddingService] ❌ Failed to embed ${type}:`, errorMessage);
             }
+            // Don't throw - return false for fire-and-forget safety
+            // Callers can check return value if they need to track success/failure
+            return false;
         }
     }
 
@@ -362,7 +382,7 @@ export class EmbeddingService {
      */
     private static flattenRecord(type: string, record: any): string | null {
         switch (type) {
-            case 'contact':
+            case 'contact': {
                 // Extract emails from JSONB array
                 const emails = record.email_jsonb || [];
                 const emailStrings = Array.isArray(emails)
@@ -398,7 +418,8 @@ export class EmbeddingService {
                 ];
 
                 return parts.filter(Boolean).join('. ') + '.';
-            case 'company':
+            }
+            case 'company': {
                 // Extract social profiles from JSONB
                 const socialProfiles = record.social_profiles || {};
                 const socialLinks: string[] = [];
@@ -442,10 +463,14 @@ export class EmbeddingService {
                 ];
 
                 return companyParts.filter(Boolean).join('. ') + '.';
+            }
             case 'deal':
                 return `${record.name} for ${record.company_name}. Category: ${record.category}. Description: ${record.description || 'No description.'}`;
-            case 'task':
+            case 'task': {
                 // Enhanced task embedding with full context
+                const dueDate = this.formatDateForEmbedding(record.due_date);
+                const doneDate = this.formatDateForEmbedding(record.done_date);
+                const createdDate = this.formatDateForEmbedding(record.created_at);
                 const taskParts = [
                     // Core task information
                     `${record.type || 'Task'}: ${record.text}`,
@@ -455,8 +480,8 @@ export class EmbeddingService {
                     record.status ? `Status: ${record.status}` : null,
 
                     // Temporal context
-                    record.due_date ? `Due: ${new Date(record.due_date).toLocaleDateString()}` : null,
-                    record.done_date ? `Completed: ${new Date(record.done_date).toLocaleDateString()}` : null,
+                    dueDate ? `Due: ${dueDate}` : null,
+                    doneDate ? `Completed: ${doneDate}` : null,
 
                     // Assignment context
                     record.assigned_to ? `Assigned to sales rep ID ${record.assigned_to}` : null,
@@ -466,14 +491,18 @@ export class EmbeddingService {
                     record.companyName ? `Company: ${record.companyName}` : null,
                     record.dealName ? `Deal: ${record.dealName}` : null,
 
+                    // Additional context for better semantic understanding
+                    createdDate ? `Created: ${createdDate}` : null,
+
                     // Archival status
                     record.archived ? 'Archived' : null,
                 ];
 
                 return taskParts.filter(Boolean).join('. ') + '.';
-
-            case 'taskNote':
+            }
+            case 'taskNote': {
                 // Task notes with hierarchical context
+                const noteDate = this.formatDateForEmbedding(record.date);
                 const taskNoteParts = [
                     // Core note content
                     `Task Note: ${record.text}`,
@@ -482,7 +511,7 @@ export class EmbeddingService {
                     record.status ? `Status: ${record.status}` : null,
 
                     // Temporal context
-                    record.date ? `Date: ${new Date(record.date).toLocaleDateString()}` : null,
+                    noteDate ? `Date: ${noteDate}` : null,
 
                     // Hierarchical context - task and contact
                     record.taskText ? `Task: ${record.taskText}` : null,
@@ -492,6 +521,7 @@ export class EmbeddingService {
                 ];
 
                 return taskNoteParts.filter(Boolean).join('. ') + '.';
+            }
 
             case 'note':
                 // For notes, we embed the text but also include the context (contact/company name)
@@ -500,4 +530,110 @@ export class EmbeddingService {
                 return null;
         }
     }
+
+    /**
+     * Embed all tasks and task notes for a specific user/entity
+     */
+    static async embedAllTasks() {
+        try {
+            // 1. Fetch all tasks
+            const { data: tasks, error: taskError } = await supabase
+                .from('tasks')
+                .select('id, type, text, priority, status, due_date, done_date, contact_id, company_id, deal_id, assigned_to, created_at, archived');
+            
+            if (taskError) {
+                console.error('[EmbeddingService] Error fetching tasks for embedding:', taskError);
+                return;
+            }
+
+            // 2. Fetch all task notes
+            const { data: taskNotes, error: noteError } = await supabase
+                .from('taskNotes')
+                .select('id, task_id, text, status, date');
+            
+            if (noteError) {
+                console.error('[EmbeddingService] Error fetching task notes for embedding:', noteError);
+            }
+
+            const tasksToProcess = tasks || [];
+            const notesToProcess = taskNotes || [];
+
+            if (tasksToProcess.length === 0 && notesToProcess.length === 0) {
+                console.log('[EmbeddingService] No tasks or notes found to embed');
+                return { success: 0, failed: 0 };
+            }
+
+            console.log(`[EmbeddingService] Processing ${tasksToProcess.length} tasks and ${notesToProcess.length} task notes for embedding`);
+            
+            let successCount = 0;
+            let failCount = 0;
+
+            // Process tasks
+            for (const task of tasksToProcess) {
+                const success = await this.embedRecord('task', task);
+                if (success) {
+                    successCount++;
+                } else {
+                    failCount++;
+                }
+            }
+
+            // Process task notes
+            for (const note of notesToProcess) {
+                const success = await this.embedRecord('taskNote', note);
+                if (success) {
+                    successCount++;
+                } else {
+                    failCount++;
+                }
+            }
+            
+            console.log(`[EmbeddingService] Completed embedding. Success: ${successCount}, Failed: ${failCount}`);
+            return { success: successCount, failed: failCount };
+        } catch (error) {
+            console.error('[EmbeddingService] Error in embedAllTasks:', error);
+            throw error;
+        }
+    }
+
+    /**
+     * Embed a specific task by ID
+     */
+    static async embedTaskById(taskId: number) {
+        const { data: task, error } = await supabase
+            .from('tasks')
+            .select('*')
+            .eq('id', taskId)
+            .single();
+
+        if (error) {
+            console.error(`[EmbeddingService] Error fetching task ${taskId} for embedding:`, error);
+            return false;
+        }
+
+        if (task) {
+            const success = await this.embedRecord('task', task);
+            if (success) {
+                console.log(`[EmbeddingService] Successfully embedded task ${taskId}`);
+            }
+            return success;
+        }
+
+        return false;
+    }
+
+    /**
+     * Embed a task object directly
+     * @throws Error if embedding fails
+     */
+    static async embedTask(task: any) {
+        const success = await this.embedRecord('task', task);
+        if (!success) {
+            const errorMsg = `Failed to embed task ${task.id || 'unknown'}`;
+            console.error(`[EmbeddingService] ${errorMsg}`);
+            throw new Error(errorMsg);
+        }
+        console.log(`[EmbeddingService] Successfully embedded task ${task.id || 'unknown'}`);
+    }
+
 }

--- a/src/lib/ai/EmbeddingService.ts
+++ b/src/lib/ai/EmbeddingService.ts
@@ -1,6 +1,13 @@
 import { supabase } from '../../components/atomic-crm/providers/supabase/supabase';
 import axios from 'axios';
 
+type TaskContext = {
+    taskText: string;
+    contactName: string | null;
+    companyName: string | null;
+    dealName: string | null;
+};
+
 /**
  * EmbeddingService
  *
@@ -11,6 +18,11 @@ export class EmbeddingService {
     // Cache for AI settings (5 minute TTL)
     private static aiSettingsCache: { data: any; timestamp: number } | null = null;
     private static readonly CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+    private static buildFullName(firstName?: string | null, lastName?: string | null): string | null {
+        const fullName = [firstName, lastName].filter(Boolean).join(' ').trim();
+        return fullName || null;
+    }
 
     /**
      * Fetch user's AI settings from database (with caching)
@@ -99,15 +111,85 @@ export class EmbeddingService {
     }
 
     /**
+     * Fetch company context for tasks (company name)
+     */
+    private static async fetchCompanyContext(companyId: number): Promise<string | null> {
+        if (!companyId) return null;
+
+        try {
+            const { data: company, error } = await supabase
+                .from('companies')
+                .select('name')
+                .eq('id', companyId)
+                .maybeSingle();
+
+            if (error || !company) {
+                console.warn('[EmbeddingService] Failed to fetch company context:', error);
+                return null;
+            }
+
+            return company.name || null;
+        } catch (error) {
+            console.warn('[EmbeddingService] Error fetching company context:', error);
+            return null;
+        }
+    }
+
+    /**
+     * Fetch deal context for tasks (deal name)
+     */
+    private static async fetchDealContext(dealId: number): Promise<string | null> {
+        if (!dealId) return null;
+
+        try {
+            const { data: deal, error } = await supabase
+                .from('deals')
+                .select('name')
+                .eq('id', dealId)
+                .maybeSingle();
+
+            if (error || !deal) {
+                console.warn('[EmbeddingService] Failed to fetch deal context:', error);
+                return null;
+            }
+
+            return deal.name || null;
+        } catch (error) {
+            console.warn('[EmbeddingService] Error fetching deal context:', error);
+            return null;
+        }
+    }
+
+    /**
      * Fetch task context for taskNotes (task text and contact)
      */
-    private static async fetchTaskContext(taskId: number): Promise<{ taskText: string; contactName: string | null } | null> {
+    private static async fetchTaskContext(taskId: number): Promise<TaskContext | null> {
         if (!taskId) return null;
 
         try {
+            const { data: taskSummary, error: summaryError } = await supabase
+                .from('tasks_summary')
+                .select('text, contact_first_name, contact_last_name, company_name, deal_name')
+                .eq('id', taskId)
+                .maybeSingle();
+
+            if (!summaryError && taskSummary) {
+                return {
+                    taskText: taskSummary.text || '',
+                    contactName: this.buildFullName(taskSummary.contact_first_name, taskSummary.contact_last_name),
+                    companyName: taskSummary.company_name || null,
+                    dealName: taskSummary.deal_name || null,
+                };
+            }
+
+            if (summaryError) {
+                console.warn('[EmbeddingService] Failed to fetch task context from tasks_summary, falling back to tasks table:', summaryError);
+            }
+
+            // Fallback for databases where tasks_summary is missing or stale
             const { data: task, error } = await supabase
                 .from('tasks')
-                .select('text, contact_id')
+                .select('text, contact_id, company_id, deal_id')
                 .eq('id', taskId)
                 .maybeSingle();
 
@@ -116,15 +198,17 @@ export class EmbeddingService {
                 return null;
             }
 
-            // Fetch contact name if contact_id exists
-            let contactName: string | null = null;
-            if (task.contact_id) {
-                contactName = await this.fetchContactContext(task.contact_id);
-            }
+            const [contactName, companyName, dealName] = await Promise.all([
+                task.contact_id ? this.fetchContactContext(task.contact_id) : Promise.resolve(null),
+                task.company_id ? this.fetchCompanyContext(task.company_id) : Promise.resolve(null),
+                task.deal_id ? this.fetchDealContext(task.deal_id) : Promise.resolve(null),
+            ]);
 
             return {
                 taskText: task.text || '',
-                contactName
+                contactName,
+                companyName,
+                dealName,
             };
         } catch (error) {
             console.warn('[EmbeddingService] Error fetching task context:', error);
@@ -142,41 +226,76 @@ export class EmbeddingService {
             return;
         }
 
+        // Ensure record has an ID before embedding
+        if (!record.id) {
+            console.warn(`[EmbeddingService] Skipping embedding for ${type} - missing ID`, record);
+            return;
+        }
+
         // Enrich record with contextual data for embedding
         let enrichedRecord = record;
-        
+
         // Fetch tag names if present
         if (record.tags && record.tags.length > 0) {
             const tagNames = await this.fetchTagNames(record.tags);
-            enrichedRecord = { ...record, tagNames };
+            enrichedRecord = { ...enrichedRecord, tagNames };
         }
 
-        // Fetch contact context for tasks
-        if (type === 'task' && record.contact_id) {
-            const contactName = await this.fetchContactContext(record.contact_id);
-            enrichedRecord = { ...enrichedRecord, contactName };
+        // Fetch relationship context for tasks
+        if (type === 'task') {
+            const inlineContactName =
+                enrichedRecord.contactName ||
+                this.buildFullName(enrichedRecord.contact_first_name, enrichedRecord.contact_last_name);
+            const inlineCompanyName = enrichedRecord.companyName || enrichedRecord.company_name || null;
+            const inlineDealName = enrichedRecord.dealName || enrichedRecord.deal_name || null;
+
+            let contactName = inlineContactName || null;
+            let companyName = inlineCompanyName;
+            let dealName = inlineDealName;
+
+            if (!contactName && !companyName && !dealName) {
+                const taskContext = await this.fetchTaskContext(record.id);
+                if (taskContext) {
+                    contactName = taskContext.contactName;
+                    companyName = taskContext.companyName;
+                    dealName = taskContext.dealName;
+                }
+            }
+
+            if (!contactName && record.contact_id) {
+                contactName = await this.fetchContactContext(record.contact_id);
+            }
+            if (!companyName && record.company_id) {
+                companyName = await this.fetchCompanyContext(record.company_id);
+            }
+            if (!dealName && record.deal_id) {
+                dealName = await this.fetchDealContext(record.deal_id);
+            }
+
+            enrichedRecord = {
+                ...enrichedRecord,
+                contactName,
+                companyName,
+                dealName,
+            };
         }
 
         // Fetch task context for taskNotes
         if (type === 'taskNote' && record.task_id) {
             const taskContext = await this.fetchTaskContext(record.task_id);
             if (taskContext) {
-                enrichedRecord = { 
-                    ...enrichedRecord, 
+                enrichedRecord = {
+                    ...enrichedRecord,
                     taskText: taskContext.taskText,
-                    contactName: taskContext.contactName
+                    contactName: taskContext.contactName,
+                    companyName: taskContext.companyName,
+                    dealName: taskContext.dealName,
                 };
             }
         }
 
         const content = this.flattenRecord(type, enrichedRecord);
         if (!content) return;
-
-        // Ensure record has an ID before embedding
-        if (!record.id) {
-            console.warn(`[EmbeddingService] Skipping embedding for ${type} - missing ID`, record);
-            return;
-        }
 
         try {
             // Log what we're actually embedding to verify completeness
@@ -330,46 +449,50 @@ export class EmbeddingService {
                 const taskParts = [
                     // Core task information
                     `${record.type || 'Task'}: ${record.text}`,
-                    
+
                     // Priority and status for filtering/relevance
                     record.priority ? `Priority: ${record.priority}` : null,
                     record.status ? `Status: ${record.status}` : null,
-                    
+
                     // Temporal context
                     record.due_date ? `Due: ${new Date(record.due_date).toLocaleDateString()}` : null,
                     record.done_date ? `Completed: ${new Date(record.done_date).toLocaleDateString()}` : null,
-                    
+
                     // Assignment context
                     record.assigned_to ? `Assigned to sales rep ID ${record.assigned_to}` : null,
-                    
+
                     // Relationship context - critical for semantic search
-                    record.contactName ? `Related to: ${record.contactName}` : null,
-                    
+                    record.contactName ? `Contact: ${record.contactName}` : null,
+                    record.companyName ? `Company: ${record.companyName}` : null,
+                    record.dealName ? `Deal: ${record.dealName}` : null,
+
                     // Archival status
                     record.archived ? 'Archived' : null,
                 ];
-                
+
                 return taskParts.filter(Boolean).join('. ') + '.';
-                
+
             case 'taskNote':
                 // Task notes with hierarchical context
                 const taskNoteParts = [
                     // Core note content
                     `Task Note: ${record.text}`,
-                    
+
                     // Status context
                     record.status ? `Status: ${record.status}` : null,
-                    
+
                     // Temporal context
                     record.date ? `Date: ${new Date(record.date).toLocaleDateString()}` : null,
-                    
+
                     // Hierarchical context - task and contact
                     record.taskText ? `Task: ${record.taskText}` : null,
                     record.contactName ? `Contact: ${record.contactName}` : null,
+                    record.companyName ? `Company: ${record.companyName}` : null,
+                    record.dealName ? `Deal: ${record.dealName}` : null,
                 ];
-                
+
                 return taskNoteParts.filter(Boolean).join('. ') + '.';
-                
+
             case 'note':
                 // For notes, we embed the text but also include the context (contact/company name)
                 return `Note: ${record.text} (Context: ${record.context_name || 'General'})`;

--- a/src/lib/ai/TaskEmbedding.test.ts
+++ b/src/lib/ai/TaskEmbedding.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Supabase client
+const { mockGetUser, mockFrom, mockAxiosPost } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockAxiosPost: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: mockAxiosPost,
+  },
+}));
+
+vi.mock("../../components/atomic-crm/providers/supabase/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  },
+}));
+
+import { EmbeddingService } from "./EmbeddingService";
+
+describe("Task Embedding Service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (EmbeddingService as any).aiSettingsCache = null;
+
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: { id: "user-1" },
+      },
+    });
+
+    mockAxiosPost.mockResolvedValue({
+      data: {
+        success: true,
+        embedding: [0.1, 0.2, 0.3, 0.4],
+        model: "text-embedding-3-small",
+      },
+    });
+
+    // Default mock for entity_vectors upsert
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "entity_vectors") {
+        return {
+          upsert: vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
+        };
+      }
+
+      if (table === "ai_settings") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { embedding_provider: "openai", embedding_model: "text-embedding-3-small" },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "tasks") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 1,
+                  type: "Follow Up",
+                  text: "Follow up with John about the proposal",
+                  priority: "high",
+                  status: "todo",
+                  due_date: "2023-12-31T00:00:00Z",
+                  contact_id: 1,
+                  company_id: null,
+                  deal_id: null,
+                  assigned_to: 1,
+                  archived: false,
+                  created_at: "2023-12-01T00:00:00Z",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "tasks_summary") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  id: 1,
+                  text: "Follow up with John about the proposal",
+                  contact_first_name: "John",
+                  contact_last_name: "Doe",
+                  company_name: "Acme Corp",
+                  deal_name: "Q4 Deal",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "contacts") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  first_name: "John",
+                  last_name: "Doe",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "companies") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Acme Corp",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "deals") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Q4 Deal",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    });
+  });
+
+  it("should properly embed a task with all context", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      priority: "high",
+      status: "todo",
+      due_date: "2023-12-31T00:00:00Z",
+      contact_id: 1,
+      company_id: null,
+      deal_id: null,
+      assigned_to: 1,
+      archived: false,
+      created_at: "2023-12-01T00:00:00Z",
+    };
+
+    await EmbeddingService.embedRecord("task", task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Follow Up: Follow up with John about the proposal");
+    expect(payload.content).toContain("Priority: high");
+    expect(payload.content).toContain("Status: todo");
+    expect(payload.content).toContain("Due: Dec 31, 2023");
+    expect(payload.content).toContain("Assigned to sales rep ID 1");
+    expect(payload.content).toContain("Created: Dec 1, 2023");
+  });
+
+  it("should embed a task with contact context", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      contact_first_name: "John",
+      contact_last_name: "Doe",
+    };
+
+    await EmbeddingService.embedRecord("task", task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Contact: John Doe");
+  });
+
+  it("should embed a task with company context", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      companyName: "Acme Corp",
+    };
+
+    await EmbeddingService.embedRecord("task", task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Company: Acme Corp");
+  });
+
+  it("should embed a task with deal context", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      dealName: "Q4 Deal",
+    };
+
+    await EmbeddingService.embedRecord("task", task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Deal: Q4 Deal");
+  });
+
+  it("should embed a specific task by ID", async () => {
+    await EmbeddingService.embedTaskById(1);
+
+    expect(mockFrom).toHaveBeenCalledWith("tasks");
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle embedding failure gracefully", async () => {
+    mockAxiosPost.mockRejectedValueOnce(new Error("Network error"));
+
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+    };
+
+    // This should throw an error that we can catch
+    await expect(EmbeddingService.embedRecord("task", task)).rejects.toThrow("Network error");
+  });
+});

--- a/src/lib/ai/TaskEmbeddingNew.test.ts
+++ b/src/lib/ai/TaskEmbeddingNew.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Supabase client
+const { mockGetUser, mockFrom, mockAxiosPost } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+  mockAxiosPost: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    post: mockAxiosPost,
+  },
+}));
+
+vi.mock("../../components/atomic-crm/providers/supabase/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  },
+}));
+
+import { EmbeddingService } from "./EmbeddingService";
+
+describe("Task Embedding Service - New embedTask Method", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (EmbeddingService as any).aiSettingsCache = null;
+
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: { id: "user-1" },
+      },
+    });
+
+    mockAxiosPost.mockResolvedValue({
+      data: {
+        success: true,
+        embedding: [0.1, 0.2, 0.3, 0.4],
+        model: "text-embedding-3-small",
+      },
+    });
+
+    // Default mock for entity_vectors upsert
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "entity_vectors") {
+        return {
+          upsert: vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
+        };
+      }
+
+      if (table === "ai_settings") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { embedding_provider: "openai", embedding_model: "text-embedding-3-small" },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "tasks_summary") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  id: 1,
+                  text: "Follow up with John about the proposal",
+                  contact_first_name: "John",
+                  contact_last_name: "Doe",
+                  company_name: "Acme Corp",
+                  deal_name: "Q4 Deal",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "contacts") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  first_name: "John",
+                  last_name: "Doe",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "companies") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Acme Corp",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      if (table === "deals") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  name: "Q4 Deal",
+                },
+                error: null,
+              }),
+            })),
+          })),
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    });
+  });
+
+  it("should properly embed a task using the new embedTask method", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      priority: "high",
+      status: "todo",
+      due_date: "2023-12-31T00:00:00Z",
+      contact_id: 1,
+      company_id: null,
+      deal_id: null,
+      assigned_to: 1,
+      archived: false,
+      created_at: "2023-12-01T00:00:00Z",
+    };
+
+    await EmbeddingService.embedTask(task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Follow Up: Follow up with John about the proposal");
+    expect(payload.content).toContain("Priority: high");
+    expect(payload.content).toContain("Status: todo");
+    expect(payload.content).toContain("Due: Dec 31, 2023");
+    expect(payload.content).toContain("Assigned to sales rep ID 1");
+    expect(payload.content).toContain("Created: Dec 1, 2023");
+  });
+
+  it("should embed a task with contact context using embedTask method", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      contact_first_name: "John",
+      contact_last_name: "Doe",
+    };
+
+    await EmbeddingService.embedTask(task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Contact: John Doe");
+  });
+
+  it("should embed a task with company context using embedTask method", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      companyName: "Acme Corp",
+    };
+
+    await EmbeddingService.embedTask(task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Company: Acme Corp");
+  });
+
+  it("should embed a task with deal context using embedTask method", async () => {
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+      dealName: "Q4 Deal",
+    };
+
+    await EmbeddingService.embedTask(task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+
+    const payload = mockAxiosPost.mock.calls[0][1];
+    expect(payload.content).toContain("Deal: Q4 Deal");
+  });
+
+  it("should handle embedding failure gracefully in embedTask method", async () => {
+    mockAxiosPost.mockRejectedValueOnce(new Error("Network error"));
+
+    const task = {
+      id: 1,
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+    };
+
+    // This should throw an error that we can catch
+    await expect(EmbeddingService.embedTask(task)).rejects.toThrow("Network error");
+  });
+
+  it("should handle task without ID gracefully", async () => {
+    const task = {
+      type: "Follow Up",
+      text: "Follow up with John about the proposal",
+    };
+
+    await EmbeddingService.embedTask(task);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(0);
+  });
+});

--- a/supabase/migrations/20260211130000_enrich_deals_summary.sql
+++ b/supabase/migrations/20260211130000_enrich_deals_summary.sql
@@ -1,0 +1,15 @@
+-- Enrich deals_summary with company_name for better semantic search and UI
+DROP VIEW IF EXISTS public.deals_summary CASCADE;
+
+CREATE VIEW public.deals_summary 
+  WITH (security_invoker=on)
+  AS
+SELECT
+  d.*,
+  c.name as company_name,
+  (SELECT count(*) FROM invoices i WHERE i.deal_id = d.id) as nb_invoices,
+  (SELECT count(*) FROM "dealNotes" dn WHERE dn.deal_id = d.id) as nb_notes
+FROM deals d
+LEFT JOIN companies c ON d.company_id = c.id;
+
+COMMENT ON VIEW public.deals_summary IS 'Enriched deals view with company name and aggregation counts';


### PR DESCRIPTION
## Summary

Major refactoring of the embedding system architecture to align with the principle: **PostgreSQL for user search, embeddings for AI assistant context**.

## Key Changes

### 🎯 Architecture Simplification
- ❌ **Removed** semantic search UI (sparkle toggles in Task/Deal lists)
- ❌ **Removed** manual "Re-index All Tasks" button
- ✅ **Clarified** embeddings as AI assistant infrastructure, not user-facing search
- ✅ **Kept** PostgreSQL full-text search as primary user search method
- ✅ **Kept** automatic background embedding for AI assistant features

### ⚡ Performance Optimizations
- **90% reduction** in embedding API calls during task creation
  - Before: 11 embedding requests per task (1 new + 10 index shifts)
  - After: 1 embedding request per task
- Smart semantic field detection:
  - **Tasks**: Only re-embed when text, status, priority, relationships change
  - **Contacts**: Skip re-embedding for metadata like last_seen
  - **Companies**: Skip re-embedding for computed aggregations
  - **Deals**: Skip re-embedding for stage/index/amount changes
  - **TaskNotes**: Only re-embed when text, status, date change

### 🛡️ Reliability Improvements
- `embedRecord()` now returns boolean instead of throwing
- Defensive checks for `result.data` and `params.data` in all lifecycle hooks
- Fixed "missing ID" errors in deal creation
- Graceful handling of malformed data structures

### 🔧 Data Provider Enhancements
- Added custom create/update handlers for deals resource
- Deals now fetch enriched data from `deals_summary` view
- Consistent enrichment pattern across all resources
- Proper error handling and fallbacks

### 📊 Database Changes
- Migration: Enriched `deals_summary` view with `company_name` field
- Aligns deals with tasks/contacts pattern for better embeddings

## Files Changed (13 files)
- `dataProvider.ts`: Smart embedding lifecycle hooks
- `EmbeddingService.ts`: Boolean returns, removed search methods
- `TaskList.tsx`, `DealList.tsx`: Removed semantic search toggles
- `AISettingsModal.tsx`: Removed re-index button
- `CHANGELOG.md`: Documented architecture changes
- Test files: Added comprehensive test coverage
- Migration: `20260211130000_enrich_deals_summary.sql`

## Testing
- ✅ TypeScript compilation passes
- ✅ Task creation: Only 1 embedding request
- ✅ Deal creation: Proper ID and enriched data
- ✅ All lifecycle hooks: Defensive checks work
- ✅ No errors in browser console

## Migration Guide
No breaking changes for end users. Embeddings continue to work automatically in the background.

---

**Rationale**: User-facing search should be fast, predictable, and reliable (PostgreSQL). Embeddings are infrastructure for future AI features (chat, recommendations, insights).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the embedding architecture by keeping PostgreSQL as the user-facing search and using embeddings only for assistant context. Removes the semantic search UI and reduces embedding calls ~90% on task creation.

- **Refactors**
  - Removed sparkle toggles in Task/Deal lists and the manual “Re-index All Tasks” button; embeddings run in the background.
  - Re-embed only when semantic fields change; skip metadata updates (e.g., index, last_seen).
  - Data provider: custom create/update for tasks and deals; return enriched records from tasks_summary/deals_summary; delete vectors on delete.
  - EmbeddingService: returns boolean, adds richer task context (contact/company/deal), stable date formatting, and bulk helpers.
  - /api/sdk/embed: validates input, adds timeouts and proper HTTP statuses, and supports both singular/plural embedding responses.

- **Migration**
  - Run supabase/migrations/20260211130000_enrich_deals_summary.sql to add company_name to deals_summary.
  - No breaking changes; user search stays on PostgreSQL and embeddings continue automatically.

<sup>Written for commit acbfef6b9f75a9fdb8757d8f0a30fb8d31ed1ddc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

